### PR TITLE
fix: Route smartwallet RPC requests to background script to avoid CSP

### DIFF
--- a/apps/extension/components/TokenScriptIframe.tsx
+++ b/apps/extension/components/TokenScriptIframe.tsx
@@ -49,9 +49,9 @@ export function TokenScriptIframe(props: {
         const data = messageData
 
         if (response?.error) {
-          data.error = response
+          data.error = response.error
         } else {
-          data.result = response
+          data.result = response.result
         }
 
         iframeRef.current?.contentWindow?.postMessage(

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -80,25 +80,25 @@ export default defineBackground(() => {
             }
           }
 
-          const res = await provider.request({
+          const result = await provider.request({
             method: rpcMethod,
             params: ["eth_accounts", "eth_requestAccounts"].includes(rpcMethod)
               ? undefined
               : params
           })
 
-          return res
+          return { result };
         } catch (e: any) {
+
+          if (e.walk) e = e.walk();
+
           return {
-            error: e.message || (e.data?.message ? " " + e.data?.message : ""),
-            message:
-              e.message || (e.data?.message ? " " + e.data?.message : ""),
-            code: e.data?.code ?? e.code
-          }
+            error: e
+          };
         }
       }
     })
 
-    return resp[0].result
+    return resp[0].result;
   }
 })

--- a/apps/extension/entrypoints/rpc-proxy.content/index.tsx
+++ b/apps/extension/entrypoints/rpc-proxy.content/index.tsx
@@ -35,7 +35,7 @@ export default defineContentScript({
           window.postMessage({
             type: "TLINK_RPC_PROXY_RSP",
             requestId: data.requestId,
-            error: (error as Error).message
+            error: error
           })
         }
       }

--- a/apps/extension/entrypoints/wallet.content/index.tsx
+++ b/apps/extension/entrypoints/wallet.content/index.tsx
@@ -1,6 +1,6 @@
 import { GlobalApiSetup } from "@/entrypoints/wallet.content/components/global-api-setup"
 import { TlinkLogo } from "@/entrypoints/wallet.content/components/tlink-logo"
-import { config, handleApiResponse } from "@/entrypoints/wallet.content/wagmi"
+import {config, handleApiResponse, sendApiRequest} from "@/entrypoints/wallet.content/wagmi"
 import { WalletConnector } from "@/entrypoints/wallet.content/wallet-connector"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { useState } from "react"
@@ -57,6 +57,50 @@ export default defineContentScript({
     // Create a root and render the App component
     const root = ReactDOM.createRoot(container)
     root.render(<App />)
+
+    window.fetch = new Proxy(window.fetch, {
+      apply: async function (target, that, args) {
+
+        // Route RPC request for coinbase smartwallet through the extension transport interface.
+        // It can't be done with custom wagmi transport as it's not used by the coinbase SDK.
+        if (args[0].startsWith("https://chain-proxy.wallet.coinbase.com")){
+          const decoded = JSON.parse(args[1].body);
+          console.log("REQUEST INTERCEPTED!", args, decoded);
+          try {
+            const result = await sendApiRequest(args[0], decoded.method, decoded.params);
+            console.log("Response: ", result)
+
+            //if (result.error)
+              //throw result.error;
+
+            return {
+              ok: true,
+              status: 200,
+              json: () => {
+                return result;
+              }
+            } as Response
+
+          } catch (error) {
+
+            console.log("RPC Error: ", error);
+
+            return {
+              ok: true,
+              status: 200,
+              json: () => {
+                return {
+                  ...decoded,
+                  error
+                }
+              }
+            }
+          }
+        }
+
+        return target.apply(that, args);
+      }
+    });
 
     // Return a cleanup function
     return () => {

--- a/apps/extension/entrypoints/wallet.content/index.tsx
+++ b/apps/extension/entrypoints/wallet.content/index.tsx
@@ -65,10 +65,10 @@ export default defineContentScript({
         // It can't be done with custom wagmi transport as it's not used by the coinbase SDK.
         if (args[0].startsWith("https://chain-proxy.wallet.coinbase.com")){
           const decoded = JSON.parse(args[1].body);
-          console.log("REQUEST INTERCEPTED!", args, decoded);
+
           try {
+
             const result = await sendApiRequest(args[0], decoded.method, decoded.params);
-            console.log("Response: ", result)
 
             //if (result.error)
               //throw result.error;

--- a/apps/extension/entrypoints/wallet.content/wagmi.ts
+++ b/apps/extension/entrypoints/wallet.content/wagmi.ts
@@ -41,13 +41,13 @@ export function handleApiResponse(event: MessageEvent) {
       if (response.error) {
         request.reject(new Error(response.error))
       } else {
-        request.resolve(response.response.result)
+        request.resolve(response.response)
       }
     }
   }
 }
 
-function sendApiRequest(
+export function sendApiRequest(
   url: string,
   method: string,
   params?: any


### PR DESCRIPTION
Twitter security policy prevents API requests within content scripts. In the Wagmi transport config, we already proxy these requests to the background scripts, however the coinbase SDK uses it’s own transport resulting in blocked RPC calls. To solve this we can implement a proxy on the fetch API and redirect known RPC URLS to the background script in the same way we do for Wagmi.

This PR also fixes various issues with propagation of RPC revert errors back to TS viewer.