### PR TITLE
feat: experimental captcha support

### DIFF
--- a/apps/extension/components/TokenScriptIframe.tsx
+++ b/apps/extension/components/TokenScriptIframe.tsx
@@ -16,21 +16,36 @@ export function TokenScriptIframe(props: {
       }
 
       if (event.data?.source === "TLINK_API_REQUEST") {
-        iframeRef.current?.contentWindow?.postMessage(
-          {
+        try {
+          iframeRef.current?.contentWindow?.postMessage(
+              {
+                type: "TLINK_API_RESPONSE",
+                source: "TLINK_API_RESPONSE",
+                data: {
+                  uid: event.data.data.uid,
+                  method: event.data.data.method,
+                  response: await handleTlinkApiRequest(
+                      event.data.data.method,
+                      event.data.data.payload
+                  )
+                }
+              },
+              "*"
+          )
+        } catch (e) {
+          console.error("TLink API request failed: ", e);
+          iframeRef.current?.contentWindow?.postMessage({
             type: "TLINK_API_RESPONSE",
             source: "TLINK_API_RESPONSE",
             data: {
               uid: event.data.data.uid,
               method: event.data.data.method,
-              response: handleTlinkApiRequest(
-                event.data.data.method,
-                event.data.data.payload
-              )
+              error: e.message
             }
-          },
-          "*"
-        )
+          }, "*");
+        }
+
+        return;
       }
 
       if (event.data?.source === "tlink") {

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -1,24 +1,9 @@
-import {getTwitterHandle} from "@/lib/get-twitter-handle.ts";
 
 export default defineBackground(() => {
   // never mark the function here async
   chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (!sender.tab || !sender.tab.id) {
       return null
-    }
-
-    if (msg.type === "TLINK_API_REQUEST"){
-
-      console.log("Handling TLink API request from background: ", msg);
-
-      handleTlinkApiRequest(msg.method, msg.payload).then((res) => {
-        sendResponse(res);
-      }).catch((err) => {
-        // TODO: Error handling
-        console.error("error handling message", err, msg);
-      })
-
-      return true;
     }
 
     let rpcMethod: string = ""
@@ -58,54 +43,6 @@ export default defineBackground(() => {
 
     return true
   })
-
-  async function handleTlinkApiRequest(method: string, payload: any) {
-    switch (method) {
-      case "getTurnstileToken":
-      case "getRecaptchaToken":
-        return handleTlinkApiViaTSViewerWindow(method, payload);
-    }
-  }
-
-  async function handleTlinkApiViaTSViewerWindow(method: string, payload: any){
-
-    return new Promise(async (resolve, reject) => {
-
-      let popup: WindowProxy|null;
-
-      const requestUrl = `http://localhost:3333/?viewType=tlink-api&method=${method}&payload=${encodeURIComponent(JSON.stringify(payload))}`
-
-      function handleMessage(event: MessageEvent){
-        if (event.source !== popup) {
-          return
-        }
-
-        popup!.onclose = null;
-
-        resolve(event.data);
-      }
-
-      window.addEventListener("message", handleMessage);
-
-
-      //popup = window.open(requestUrl, "", 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=550px,height=800px`');
-      popup = await chrome.windows.create({
-        url: requestUrl,
-        type: 'popup',
-        focused: true,
-        setSelfAsOpener: true
-        // incognito, top, left, ...
-      }) as WindowProxy;
-
-      if (!popup)
-        reject("Failed to open the popup window");
-
-      popup!.onclose = () => {
-        reject("Popup closed");
-      }
-
-    });
-  }
 
   async function handleWalletCommunication({
     tabId,

--- a/apps/extension/entrypoints/sandbox/index.html
+++ b/apps/extension/entrypoints/sandbox/index.html
@@ -17,11 +17,6 @@
         height: 100%;
       }
     </style>
-    <script async src="https://www.google.com/recaptcha/api.js?render=explicit"></script>
-    <script
-            src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
-            defer
-    ></script>
   </head>
   <body>
     <div id="root">
@@ -33,92 +28,6 @@
         sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals"></iframe>
     </div>
     <script>
-      const DEFAULT_RC_SITE_KEY = "6LeXSIIqAAAAAJlp04ct42518YoNJeWiUtUTItTb";
-
-      const widgetIds = {};
-
-      async function getRecaptchaToken(sitekey, action){
-
-        return new Promise((resolve, reject) => {
-
-          if (!sitekey)
-            sitekey = DEFAULT_RC_SITE_KEY;
-
-          grecaptcha.ready(function() {
-            const elemId = `recaptcha-${sitekey}`;
-            let widgetId;
-            if (widgetIds[sitekey] === undefined){
-              const elem = document.createElement("div");
-              elem.id = elemId;
-              document.body.append(elem);
-              widgetId = grecaptcha.render(elemId, {
-                sitekey,
-                size: 'invisible'
-              });
-              widgetIds[sitekey] = widgetId;
-            } else {
-              widgetId = widgetIds[sitekey];
-              const elem = document.getElementById(elemId).getElementsByClassName("grecaptcha-badge")[0];
-              if (elem) elem.style.visibility = "visible";
-            }
-
-            grecaptcha.execute(widgetId, {action: action ?? "recaptcha"}).then(function(token) {
-              resolve(token);
-              setTimeout(() => {
-                const elem = document.getElementById(elemId).getElementsByClassName("grecaptcha-badge")[0];
-                if (elem) elem.style.visibility = "hidden";
-              }, 5000);
-            }).catch(e => {
-              reject(e);
-            });
-          });
-        })
-      }
-
-      const DEFAULT_TS_SITE_KEY = "0x4AAAAAAA0Rmw6kZyekmiSB";
-
-      async function getTurnstileToken(sitekey){
-
-        return new Promise((resolve, reject) => {
-
-          if (!sitekey)
-            sitekey = DEFAULT_TS_SITE_KEY;
-
-          const elemId = `turnstile-${sitekey}`;
-          let elem;
-
-          try {
-            let widgetId;
-
-            if (!document.getElementById(elemId)) {
-              elem = document.createElement("div");
-              elem.id = elemId;
-              elem.classList.add("turnstile-widget");
-              document.body.append(elem);
-            }
-
-            widgetId = turnstile.render("#" + elemId, {
-              sitekey,
-              callback: function (token) {
-                console.log(`Challenge Success ${token}`);
-                resolve(token);
-                turnstile.remove(widgetId);
-                elem.remove();
-              },
-              'error-callback': function (error){
-                console.error("Turnstile error: ", error);
-                turnstile.remove(widgetId);
-                elem.remove();
-                reject(error);
-              }
-            });
-          } catch (e){
-            reject(e);
-            if (elem)
-              elem.remove();
-          }
-        })
-      }
 
       ;(function () {
         const iframe = document.getElementById("tlink-iframe")
@@ -134,36 +43,6 @@
           }
 
           if (event.data.type === "TLINK_API_REQUEST") {
-
-            // grecaptcha must be loaded in the extension context
-            const req = event.data.data;
-
-            if (req.method === "getRecaptchaToken") {
-              event.data.source = "TLINK_API_RESPONSE";
-              try {
-                const response = await getRecaptchaToken(req.payload?.sitekey, req.payload.action);
-                event.data.data.response = response;
-              } catch (e){
-                console.error(e);
-                event.data.data.error = e.message;
-              }
-              iframe?.contentWindow?.postMessage(event.data, "*");
-              return;
-            }
-
-            if (req.method === "getTurnstileToken") {
-              event.data.source = "TLINK_API_RESPONSE";
-              try {
-                const response = await getTurnstileToken(req.payload?.sitekey);
-                event.data.data.response = response;
-              } catch (e){
-                console.error(e);
-                event.data.data.error = e.message;
-              }
-              iframe?.contentWindow?.postMessage(event.data, "*");
-              return;
-            }
-
             // forward ts viewer API request out
             window.parent.postMessage(
               { source: "TLINK_API_REQUEST", data: event.data.data },

--- a/apps/extension/entrypoints/sandbox/index.html
+++ b/apps/extension/entrypoints/sandbox/index.html
@@ -17,6 +17,11 @@
         height: 100%;
       }
     </style>
+    <script async src="https://www.google.com/recaptcha/api.js?render=explicit"></script>
+    <script
+            src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+            defer
+    ></script>
   </head>
   <body>
     <div id="root">
@@ -28,10 +33,97 @@
         sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals"></iframe>
     </div>
     <script>
+      const DEFAULT_RC_SITE_KEY = "6LeXSIIqAAAAAJlp04ct42518YoNJeWiUtUTItTb";
+
+      const widgetIds = {};
+
+      async function getRecaptchaToken(sitekey, action){
+
+        return new Promise((resolve, reject) => {
+
+          if (!sitekey)
+            sitekey = DEFAULT_RC_SITE_KEY;
+
+          grecaptcha.ready(function() {
+            const elemId = `recaptcha-${sitekey}`;
+            let widgetId;
+            if (widgetIds[sitekey] === undefined){
+              const elem = document.createElement("div");
+              elem.id = elemId;
+              document.body.append(elem);
+              widgetId = grecaptcha.render(elemId, {
+                sitekey,
+                size: 'invisible'
+              });
+              widgetIds[sitekey] = widgetId;
+            } else {
+              widgetId = widgetIds[sitekey];
+              const elem = document.getElementById(elemId).getElementsByClassName("grecaptcha-badge")[0];
+              if (elem) elem.style.visibility = "visible";
+            }
+
+            grecaptcha.execute(widgetId, {action: action ?? "recaptcha"}).then(function(token) {
+              resolve(token);
+              setTimeout(() => {
+                const elem = document.getElementById(elemId).getElementsByClassName("grecaptcha-badge")[0];
+                if (elem) elem.style.visibility = "hidden";
+              }, 5000);
+            }).catch(e => {
+              reject(e);
+            });
+          });
+        })
+      }
+
+      const DEFAULT_TS_SITE_KEY = "0x4AAAAAAA0Rmw6kZyekmiSB";
+
+      async function getTurnstileToken(sitekey){
+
+        return new Promise((resolve, reject) => {
+
+          if (!sitekey)
+            sitekey = DEFAULT_TS_SITE_KEY;
+
+          const elemId = `turnstile-${sitekey}`;
+          let elem;
+
+          try {
+            let widgetId;
+
+            if (!document.getElementById(elemId)) {
+              elem = document.createElement("div");
+              elem.id = elemId;
+              elem.classList.add("turnstile-widget");
+              document.body.append(elem);
+            }
+
+            widgetId = turnstile.render("#" + elemId, {
+              sitekey,
+              callback: function (token) {
+                console.log(`Challenge Success ${token}`);
+                resolve(token);
+                turnstile.remove(widgetId);
+                elem.remove();
+              },
+              'error-callback': function (error){
+                console.error("Turnstile error: ", error);
+                turnstile.remove(widgetId);
+                elem.remove();
+                reject(error);
+              }
+            });
+          } catch (e){
+            reject(e);
+            if (elem)
+              elem.remove();
+          }
+        })
+      }
+
       ;(function () {
         const iframe = document.getElementById("tlink-iframe")
 
-        function handleMessage(event) {
+        async function handleMessage(event) {
           // We only proxy messages that originate from the child iframe or parent window
           // This prevents postMessage listeners of other tlink iframes on the same page causing duplicate requests to the background service
           if (
@@ -42,6 +134,36 @@
           }
 
           if (event.data.type === "TLINK_API_REQUEST") {
+
+            // grecaptcha must be loaded in the extension context
+            const req = event.data.data;
+
+            if (req.method === "getRecaptchaToken") {
+              event.data.source = "TLINK_API_RESPONSE";
+              try {
+                const response = await getRecaptchaToken(req.payload?.sitekey, req.payload.action);
+                event.data.data.response = response;
+              } catch (e){
+                console.error(e);
+                event.data.data.error = e.message;
+              }
+              iframe?.contentWindow?.postMessage(event.data, "*");
+              return;
+            }
+
+            if (req.method === "getTurnstileToken") {
+              event.data.source = "TLINK_API_RESPONSE";
+              try {
+                const response = await getTurnstileToken(req.payload?.sitekey);
+                event.data.data.response = response;
+              } catch (e){
+                console.error(e);
+                event.data.data.error = e.message;
+              }
+              iframe?.contentWindow?.postMessage(event.data, "*");
+              return;
+            }
+
             // forward ts viewer API request out
             window.parent.postMessage(
               { source: "TLINK_API_REQUEST", data: event.data.data },

--- a/apps/extension/lib/handle-tlink-api.ts
+++ b/apps/extension/lib/handle-tlink-api.ts
@@ -50,7 +50,7 @@ async function handleTlinkApiViaTSViewerWindow(method: string, payload: any){
 
         window.addEventListener("message", handleMessage);
 
-        popup = window.open(requestUrl, "", 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=250px,height=250px`');
+        popup = popupCenter(requestUrl, "TLink Request", 400, 400);
 
         if (!popup)
             reject(new Error("Failed to open the popup window"));
@@ -62,4 +62,10 @@ async function handleTlinkApiViaTSViewerWindow(method: string, payload: any){
         }, 1000)
 
     });
+}
+
+function popupCenter (url, title, w, h) {
+    const left = (screen.width/2)-(w/2);
+    const top = (screen.height/2)-(h/2);
+    return window.open(url, title, 'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, resizable=yes, copyhistory=no, width='+w+', height='+h+', top='+top+', left='+left);
 }

--- a/apps/extension/lib/handle-tlink-api.ts
+++ b/apps/extension/lib/handle-tlink-api.ts
@@ -10,11 +10,6 @@ export async function handleTlinkApiRequest(method: string, payload: any) {
       }
     case "getTurnstileToken":
     case "getRecaptchaToken":
-     /*return await chrome.runtime.sendMessage({
-        type: "TLINK_API_REQUEST",
-        method,
-        payload
-      })*/
       return await handleTlinkApiViaTSViewerWindow(method, payload);
   }
 

--- a/apps/extension/lib/handle-tlink-api.ts
+++ b/apps/extension/lib/handle-tlink-api.ts
@@ -1,6 +1,6 @@
 import { getTwitterHandle } from "@/lib/get-twitter-handle"
 
-export function handleTlinkApiRequest(method: string, payload: any) {
+export async function handleTlinkApiRequest(method: string, payload: any) {
   switch (method) {
     case "getTlinkContext":
       return {
@@ -8,7 +8,58 @@ export function handleTlinkApiRequest(method: string, payload: any) {
         API_KEY:
           "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0IjoibXVsdGktY2hhbm5lbC1yZW5kZXJpbmctdGxpbmsiLCJpYXQiOjE3MjcxNzE1MDl9.9864en0XJbVgzACE_gHrQ00mr6fgctNRXWZ0Nex3DcQ"
       }
+    case "getTurnstileToken":
+    case "getRecaptchaToken":
+     /*return await chrome.runtime.sendMessage({
+        type: "TLINK_API_REQUEST",
+        method,
+        payload
+      })*/
+      return await handleTlinkApiViaTSViewerWindow(method, payload);
   }
 
   return null
+}
+
+async function handleTlinkApiViaTSViewerWindow(method: string, payload: any){
+
+    return new Promise(async (resolve, reject) => {
+
+        let popup: WindowProxy|null;
+        let closedTimer;
+
+        const requestUrl = `http://localhost:3333/?viewType=tlink-api&method=${method}&payload=${encodeURIComponent(JSON.stringify(payload))}`
+
+        function handleMessage(event: MessageEvent){
+
+            if (event.source !== popup || event.data.type !== "TLINK_API_RESPONSE") {
+                return
+            }
+
+            if (closedTimer)
+                clearInterval(closedTimer)
+
+            if (event.data.response){
+                resolve(event.data.response);
+            } else {
+                reject(new Error(event.data.error));
+            }
+
+            popup?.close();
+        }
+
+        window.addEventListener("message", handleMessage);
+
+        popup = window.open(requestUrl, "", 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=250px,height=250px`');
+
+        if (!popup)
+            reject(new Error("Failed to open the popup window"));
+
+        closedTimer = setInterval(() => {
+            if (!popup || popup.closed){
+                reject(new Error("Popup closed"));
+            }
+        }, 1000)
+
+    });
 }

--- a/apps/extension/lib/handle-tlink-api.ts
+++ b/apps/extension/lib/handle-tlink-api.ts
@@ -1,4 +1,5 @@
 import { getTwitterHandle } from "@/lib/get-twitter-handle"
+import {TS_VIEWER_URL} from "@repo/tlinks/utils";
 
 export async function handleTlinkApiRequest(method: string, payload: any) {
   switch (method) {
@@ -23,7 +24,7 @@ async function handleTlinkApiViaTSViewerWindow(method: string, payload: any){
         let popup: WindowProxy|null;
         let closedTimer;
 
-        const requestUrl = `http://localhost:3333/?viewType=tlink-api&method=${method}&payload=${encodeURIComponent(JSON.stringify(payload))}`
+        const requestUrl = `${TS_VIEWER_URL}?viewType=tlink-api&method=${method}&payload=${encodeURIComponent(JSON.stringify(payload))}`
 
         function handleMessage(event: MessageEvent){
 
@@ -59,7 +60,7 @@ async function handleTlinkApiViaTSViewerWindow(method: string, payload: any){
     });
 }
 
-function popupCenter (url, title, w, h) {
+function popupCenter(url: string, title: string, w: number, h: number) {
     const left = (screen.width/2)-(w/2);
     const top = (screen.height/2)-(h/2);
     return window.open(url, title, 'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, resizable=yes, copyhistory=no, width='+w+', height='+h+', top='+top+', left='+left);

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     content_security_policy: {
       extension_pages: "script-src 'self'; object-src 'self';",
       sandbox:
-        "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/ https://www.gstatic.com/ https://recaptcha.google.com/ https://challenges.cloudflare.com/; child-src 'self' https://viewer.tokenscript.org/ https://viewer-staging.tokenscript.org/ http://localhost:3333/ https://www.google.com/ https://challenges.cloudflare.com/; worker-src 'self' https://www.google.com/;"
+        "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals; script-src 'self' 'unsafe-inline' 'unsafe-eval'; child-src 'self' https://viewer.tokenscript.org/ https://viewer-staging.tokenscript.org/ http://localhost:3333/;"
     }
   },
   modules: ["@wxt-dev/module-react"]

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     content_security_policy: {
       extension_pages: "script-src 'self'; object-src 'self';",
       sandbox:
-        "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals; script-src 'self' 'unsafe-inline' 'unsafe-eval'; child-src 'self' https://viewer.tokenscript.org/ https://viewer-staging.tokenscript.org/ http://localhost:3333/;"
+        "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/ https://www.gstatic.com/ https://recaptcha.google.com/ https://challenges.cloudflare.com/; child-src 'self' https://viewer.tokenscript.org/ https://viewer-staging.tokenscript.org/ http://localhost:3333/ https://www.google.com/ https://challenges.cloudflare.com/; worker-src 'self' https://www.google.com/;"
     }
   },
   modules: ["@wxt-dev/module-react"]

--- a/packages/tlinks/src/utils/build-ts-ifram-url.ts
+++ b/packages/tlinks/src/utils/build-ts-ifram-url.ts
@@ -1,3 +1,5 @@
+import {TS_VIEWER_URL} from "./constants.ts";
+
 export const buildTsIframeUrl = ({
   chainId,
   contract,
@@ -26,7 +28,7 @@ export const buildTsIframeUrl = ({
   if (tokenId) dAppUrlParams.append('tokenId', tokenId);
   if (scriptId) dAppUrlParams.append('scriptId', scriptId);
 
-  return `https://viewer-staging.tokenscript.org/?${dAppUrlParams.toString()}${
+  return `${TS_VIEWER_URL}?${dAppUrlParams.toString()}${
     (hash || '').length > 1 ? hash : ''
   }`;
 };

--- a/packages/tlinks/src/utils/constants.ts
+++ b/packages/tlinks/src/utils/constants.ts
@@ -117,3 +117,5 @@ export class SimpleActionComponent extends AbstractActionComponent {
       };
     }
   }
+
+export const TS_VIEWER_URL = "https://viewer.tokenscript.org/";

--- a/packages/tlinks/src/utils/index.ts
+++ b/packages/tlinks/src/utils/index.ts
@@ -4,3 +4,4 @@ export { buildTsIframeUrl } from './build-ts-ifram-url.ts';
 export { fetchTlinkData, fetchTsData } from './fetch-ts-data.ts';
 export type { TokenscriptCardMetadata } from './fetch-ts-data.ts';
 export { setProxyUrl } from './proxify.ts';
+export { TS_VIEWER_URL } from './constants.ts';


### PR DESCRIPTION
Hey @futantan this PR adds captcha support to TLink. Here's how it works:

1. When a tapp requests a captcha in the context of a tlink iframe, the request is routed from viewer back to the content script.
2. The content script then opens a window back to TS viewer with a special view that processes TLink API requests. Since the popup is allowed to escape the extension sandbox, all browser APIs are available and there is not issue with loading Turnstile or Recaptcha.
3. Once the captcha is successful, the response is sent back to the extension via postmessage, then subsequently through to TS viewer and finally the tokenscript card.

This way has it's advantages since captcha logic only needs to be included in TS Viewer rather than maintaining it in separate places. The changes to Tlink extension are purely to proxy these requests to a separate TS viewer popup window.

When a tapp card is running in it's own window (or is not a tlink view) the request is processed solely within TS viewer.

To request captchas from a Tapp card:

```
await tokenscript.tlink.request({method: "getTurnstileToken", "payload": {}});

await tokenscript.tlink.request({method: "getRecaptchaToken", "payload": {}});
```

To allow any Tapp developer to use this feature, their own sitekey can be specified as a payload parameter. 
For recaptcha the action parameter can also be specified:

```
await tokenscript.tlink.request({method: "getTurnstileToken", payload: {sitekey: "MY_SITE_KEY"}});

await tokenscript.tlink.request({method: "getRecaptchaToken",payload: {sitekey: "MY_SITE_KEY", action: "my_action"}});
```

